### PR TITLE
Final check

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Database Configuration
 DB_HOST=127.0.0.1
 DB_USER=root
-DB_PASSWORD=000000
+DB_PASSWORD=12345678
 DB_NAME=covid_service
 SESSION_DB_NAME=gogo
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .history/
+.env
+node_modules/

--- a/config/env.js
+++ b/config/env.js
@@ -28,7 +28,7 @@ module.exports = {
     bcryptRounds: parseInt(process.env.BCRYPT_ROUNDS) || 12,
     rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 900000, // 15 minutes
     rateLimitMaxRequests: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 100,
-    emailRateLimitMax: parseInt(process.env.EMAIL_RATE_LIMIT_MAX) || 5,
+    emailRateLimitMax: parseInt(process.env.EMAIL_RATE_LIMIT_MAX) || 15,
     emailRateLimitWindowMs:
       parseInt(process.env.EMAIL_RATE_LIMIT_WINDOW_MS) || 300000, // 5 minutes
   },

--- a/database/database.sql
+++ b/database/database.sql
@@ -1,5 +1,6 @@
 SET FOREIGN_KEY_CHECKS = 0;
 
+DROP TABLE IF EXISTS order_reports;
 DROP TABLE IF EXISTS delivery_service;
 DROP TABLE IF EXISTS provider;
 DROP TABLE IF EXISTS providers_covid_status;
@@ -211,6 +212,34 @@ CREATE TABLE order_items (
     ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE order_reports (
+  id           BIGINT NOT NULL AUTO_INCREMENT,
+  service_id   BIGINT NOT NULL,
+  customer_id  BIGINT NOT NULL,
+  provider_id  BIGINT NOT NULL,
+  reason       TEXT   NOT NULL,
+  status       ENUM('pending','resolved') NOT NULL DEFAULT 'pending',
+  created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+
+  KEY idx_order_reports_service  (service_id),
+  KEY idx_order_reports_customer (customer_id),
+  KEY idx_order_reports_provider (provider_id),
+
+  CONSTRAINT fk_order_reports_service
+    FOREIGN KEY (service_id)
+    REFERENCES delivery_service (service_id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_order_reports_customer
+    FOREIGN KEY (customer_id)
+    REFERENCES users (user_id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_order_reports_provider
+    FOREIGN KEY (provider_id)
+    REFERENCES provider (user_id)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 
 -- 插入初始数据
 INSERT INTO users (name, user_type, email, password_hash)
@@ -321,4 +350,3 @@ VALUES
 (5, 5, 1),
 (5, 6, 1),
 (5, 7, 1);
-

--- a/middleware/security.js
+++ b/middleware/security.js
@@ -103,9 +103,7 @@ const validationRules = {
 
   businessName: body("business_name")
     .isLength({ min: 2, max: 100 })
-    .withMessage("Business name must be between 2 and 100 characters")
-    .matches(/^[a-zA-Z0-9\s\-&.,]+$/)
-    .withMessage("Business name contains invalid characters"),
+    .withMessage("Business name must be between 2 and 100 characters"),
 
   description: body("description")
     .isLength({ max: 500 })
@@ -117,21 +115,15 @@ const validationRules = {
 
   city: body("city")
     .isLength({ min: 2, max: 100 })
-    .withMessage("City must be between 2 and 100 characters")
-    .matches(/^[a-zA-Z\s]+$/)
-    .withMessage("City can only contain letters and spaces"),
+    .withMessage("City must be between 2 and 100 characters"),
 
   state: body("state")
     .isLength({ min: 2, max: 50 })
-    .withMessage("State must be between 2 and 50 characters")
-    .matches(/^[a-zA-Z\s]+$/)
-    .withMessage("State can only contain letters and spaces"),
+    .withMessage("State must be between 2 and 50 characters"),
 
   postcode: body("postcode")
     .isLength({ min: 4, max: 10 })
-    .withMessage("Postcode must be between 4 and 10 characters")
-    .matches(/^[a-zA-Z0-9\s]+$/)
-    .withMessage("Postcode contains invalid characters"),
+    .withMessage("Postcode must be between 4 and 10 characters"),
 
   covidStatus: body("state_name")
     .isIn(["Green", "Yellow", "Red"])

--- a/node_modules/.bin/bcrypt
+++ b/node_modules/.bin/bcrypt
@@ -1,16 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=`cygpath -w "$basedir"`
-        fi
-    ;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../bcryptjs/bin/bcrypt" "$@"
-else 
-  exec node  "$basedir/../bcryptjs/bin/bcrypt" "$@"
-fi
+../bcryptjs/bin/bcrypt

--- a/node_modules/.bin/cross-env
+++ b/node_modules/.bin/cross-env
@@ -1,16 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=`cygpath -w "$basedir"`
-        fi
-    ;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../cross-env/dist/bin/cross-env.js" "$@"
-else 
-  exec node  "$basedir/../cross-env/dist/bin/cross-env.js" "$@"
-fi
+../cross-env/dist/bin/cross-env.js

--- a/node_modules/.bin/cross-env-shell
+++ b/node_modules/.bin/cross-env-shell
@@ -1,16 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=`cygpath -w "$basedir"`
-        fi
-    ;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../cross-env/dist/bin/cross-env-shell.js" "$@"
-else 
-  exec node  "$basedir/../cross-env/dist/bin/cross-env-shell.js" "$@"
-fi
+../cross-env/dist/bin/cross-env-shell.js

--- a/node_modules/.bin/is-docker
+++ b/node_modules/.bin/is-docker
@@ -1,16 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=`cygpath -w "$basedir"`
-        fi
-    ;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../is-docker/cli.js" "$@"
-else 
-  exec node  "$basedir/../is-docker/cli.js" "$@"
-fi
+../is-docker/cli.js

--- a/node_modules/.bin/is-inside-container
+++ b/node_modules/.bin/is-inside-container
@@ -1,16 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=`cygpath -w "$basedir"`
-        fi
-    ;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../is-inside-container/cli.js" "$@"
-else 
-  exec node  "$basedir/../is-inside-container/cli.js" "$@"
-fi
+../is-inside-container/cli.js

--- a/node_modules/.bin/node-which
+++ b/node_modules/.bin/node-which
@@ -1,16 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=`cygpath -w "$basedir"`
-        fi
-    ;;
-esac
-
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../which/bin/node-which" "$@"
-else 
-  exec node  "$basedir/../which/bin/node-which" "$@"
-fi
+../which/bin/node-which

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/bcryptjs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
-      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
@@ -891,9 +891,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
-      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.0.1"

--- a/node_modules/bcryptjs/index.js
+++ b/node_modules/bcryptjs/index.js
@@ -326,19 +326,17 @@ export function truncates(password) {
 }
 
 /**
- * Continues with the callback on the next tick.
+ * Continues with the callback after yielding to the event loop.
  * @function
  * @param {function(...[*])} callback Callback to execute
  * @inner
  */
 var nextTick =
-  typeof process !== "undefined" &&
-  process &&
-  typeof process.nextTick === "function"
-    ? typeof setImmediate === "function"
-      ? setImmediate
-      : process.nextTick
-    : setTimeout;
+  typeof setImmediate === "function"
+    ? setImmediate
+    : typeof scheduler === "object" && typeof scheduler.postTask === "function"
+      ? scheduler.postTask.bind(scheduler)
+      : setTimeout;
 
 /** Calculates the byte length of a string encoded as UTF8. */
 function utf8Length(string) {

--- a/node_modules/bcryptjs/package.json
+++ b/node_modules/bcryptjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bcryptjs",
   "description": "Optimized bcrypt in plain JavaScript with zero dependencies, with TypeScript support. Compatible to 'bcrypt'.",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "Daniel Wirtz <dcode@dcode.io>",
   "contributors": [
     "Shane Girish <shaneGirish@gmail.com> (https://github.com/shaneGirish)",

--- a/node_modules/bcryptjs/umd/index.js
+++ b/node_modules/bcryptjs/umd/index.js
@@ -381,19 +381,18 @@
     }
 
     /**
-     * Continues with the callback on the next tick.
+     * Continues with the callback after yielding to the event loop.
      * @function
      * @param {function(...[*])} callback Callback to execute
      * @inner
      */
     var nextTick =
-      typeof process !== "undefined" &&
-      process &&
-      typeof process.nextTick === "function"
-        ? typeof setImmediate === "function"
-          ? setImmediate
-          : process.nextTick
-        : setTimeout;
+      typeof setImmediate === "function"
+        ? setImmediate
+        : typeof scheduler === "object" &&
+            typeof scheduler.postTask === "function"
+          ? scheduler.postTask.bind(scheduler)
+          : setTimeout;
 
     /** Calculates the byte length of a string encoded as UTF8. */
     function utf8Length(string) {

--- a/node_modules/express-rate-limit/dist/index.cjs
+++ b/node_modules/express-rate-limit/dist/index.cjs
@@ -521,12 +521,54 @@ var validations = {
       );
     }
   },
+  knownOptions(passedOptions) {
+    if (!passedOptions) return;
+    const optionsMap = {
+      windowMs: true,
+      limit: true,
+      message: true,
+      statusCode: true,
+      legacyHeaders: true,
+      standardHeaders: true,
+      identifier: true,
+      requestPropertyName: true,
+      skipFailedRequests: true,
+      skipSuccessfulRequests: true,
+      keyGenerator: true,
+      ipv6Subnet: true,
+      handler: true,
+      skip: true,
+      requestWasSuccessful: true,
+      store: true,
+      validate: true,
+      headers: true,
+      max: true,
+      passOnStoreError: true
+    };
+    const validOptions = Object.keys(optionsMap).concat(
+      "draft_polli_ratelimit_headers",
+      // not a valid option anymore, but we have a more specific check for this one, so don't warn for it here
+      // from express-slow-down - https://github.com/express-rate-limit/express-slow-down/blob/main/source/types.ts#L65
+      "delayAfter",
+      "delayMs",
+      "maxDelayMs"
+    );
+    for (const key of Object.keys(passedOptions)) {
+      if (!validOptions.includes(key)) {
+        throw new ValidationError(
+          "ERR_ERL_UNKNOWN_OPTION",
+          `Unexpected configuration option: ${key}`
+          // todo: suggest a valid option with a short levenstein distance?
+        );
+      }
+    }
+  },
   /**
    * Checks the options.validate setting to ensure that only recognized
    * validations are enabled or disabled.
    *
    * If any unrecognized values are found, an error is logged that
-   * includes the list of supported vaidations.
+   * includes the list of supported validations.
    */
   validationsConfig() {
     const supportedValidations = Object.keys(this).filter(
@@ -696,6 +738,7 @@ var parseOptions = (passedOptions) => {
   const notUndefinedOptions = omitUndefinedProperties(passedOptions);
   const validations2 = getValidations(notUndefinedOptions?.validate ?? true);
   validations2.validationsConfig();
+  validations2.knownOptions(passedOptions);
   validations2.draftPolliHeaders(
     // @ts-expect-error see the note above.
     notUndefinedOptions.draft_polli_ratelimit_headers

--- a/node_modules/express-rate-limit/dist/index.d.cts
+++ b/node_modules/express-rate-limit/dist/index.d.cts
@@ -132,12 +132,13 @@ declare const validations: {
 	 * @returns {void}
 	 */
 	headersResetTime(resetTime?: Date): void;
+	knownOptions(passedOptions?: Partial<Options>): void;
 	/**
 	 * Checks the options.validate setting to ensure that only recognized
 	 * validations are enabled or disabled.
 	 *
 	 * If any unrecognized values are found, an error is logged that
-	 * includes the list of supported vaidations.
+	 * includes the list of supported validations.
 	 */
 	validationsConfig(): void;
 	/**

--- a/node_modules/express-rate-limit/dist/index.d.mts
+++ b/node_modules/express-rate-limit/dist/index.d.mts
@@ -132,12 +132,13 @@ declare const validations: {
 	 * @returns {void}
 	 */
 	headersResetTime(resetTime?: Date): void;
+	knownOptions(passedOptions?: Partial<Options>): void;
 	/**
 	 * Checks the options.validate setting to ensure that only recognized
 	 * validations are enabled or disabled.
 	 *
 	 * If any unrecognized values are found, an error is logged that
-	 * includes the list of supported vaidations.
+	 * includes the list of supported validations.
 	 */
 	validationsConfig(): void;
 	/**

--- a/node_modules/express-rate-limit/dist/index.d.ts
+++ b/node_modules/express-rate-limit/dist/index.d.ts
@@ -132,12 +132,13 @@ declare const validations: {
 	 * @returns {void}
 	 */
 	headersResetTime(resetTime?: Date): void;
+	knownOptions(passedOptions?: Partial<Options>): void;
 	/**
 	 * Checks the options.validate setting to ensure that only recognized
 	 * validations are enabled or disabled.
 	 *
 	 * If any unrecognized values are found, an error is logged that
-	 * includes the list of supported vaidations.
+	 * includes the list of supported validations.
 	 */
 	validationsConfig(): void;
 	/**

--- a/node_modules/express-rate-limit/dist/index.mjs
+++ b/node_modules/express-rate-limit/dist/index.mjs
@@ -492,12 +492,54 @@ var validations = {
       );
     }
   },
+  knownOptions(passedOptions) {
+    if (!passedOptions) return;
+    const optionsMap = {
+      windowMs: true,
+      limit: true,
+      message: true,
+      statusCode: true,
+      legacyHeaders: true,
+      standardHeaders: true,
+      identifier: true,
+      requestPropertyName: true,
+      skipFailedRequests: true,
+      skipSuccessfulRequests: true,
+      keyGenerator: true,
+      ipv6Subnet: true,
+      handler: true,
+      skip: true,
+      requestWasSuccessful: true,
+      store: true,
+      validate: true,
+      headers: true,
+      max: true,
+      passOnStoreError: true
+    };
+    const validOptions = Object.keys(optionsMap).concat(
+      "draft_polli_ratelimit_headers",
+      // not a valid option anymore, but we have a more specific check for this one, so don't warn for it here
+      // from express-slow-down - https://github.com/express-rate-limit/express-slow-down/blob/main/source/types.ts#L65
+      "delayAfter",
+      "delayMs",
+      "maxDelayMs"
+    );
+    for (const key of Object.keys(passedOptions)) {
+      if (!validOptions.includes(key)) {
+        throw new ValidationError(
+          "ERR_ERL_UNKNOWN_OPTION",
+          `Unexpected configuration option: ${key}`
+          // todo: suggest a valid option with a short levenstein distance?
+        );
+      }
+    }
+  },
   /**
    * Checks the options.validate setting to ensure that only recognized
    * validations are enabled or disabled.
    *
    * If any unrecognized values are found, an error is logged that
-   * includes the list of supported vaidations.
+   * includes the list of supported validations.
    */
   validationsConfig() {
     const supportedValidations = Object.keys(this).filter(
@@ -667,6 +709,7 @@ var parseOptions = (passedOptions) => {
   const notUndefinedOptions = omitUndefinedProperties(passedOptions);
   const validations2 = getValidations(notUndefinedOptions?.validate ?? true);
   validations2.validationsConfig();
+  validations2.knownOptions(passedOptions);
   validations2.draftPolliHeaders(
     // @ts-expect-error see the note above.
     notUndefinedOptions.draft_polli_ratelimit_headers

--- a/node_modules/express-rate-limit/package.json
+++ b/node_modules/express-rate-limit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "express-rate-limit",
-	"version": "8.1.0",
+	"version": "8.2.1",
 	"description": "Basic IP rate-limiting middleware for Express. Use to limit repeated requests to public APIs and/or endpoints such as password reset.",
 	"author": {
 		"name": "Nathan Friedly",
@@ -77,29 +77,29 @@
 		"express": ">= 4.11"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.2.2",
+		"@biomejs/biome": "2.3.1",
 		"@express-rate-limit/prettier": "1.1.1",
 		"@express-rate-limit/tsconfig": "1.0.2",
-		"@jest/globals": "30.1.2",
-		"@types/express": "5.0.3",
+		"@jest/globals": "30.2.0",
+		"@types/express": "5.0.4",
 		"@types/jest": "30.0.0",
-		"@types/node": "24.3.0",
+		"@types/node": "24.9.1",
 		"@types/supertest": "6.0.3",
 		"del-cli": "6.0.0",
 		"dts-bundle-generator": "8.1.2",
-		"esbuild": "0.25.9",
+		"esbuild": "0.25.11",
 		"express": "5.1.0",
 		"husky": "9.1.7",
-		"jest": "30.1.2",
-		"lint-staged": "16.1.6",
-		"mintlify": "4.2.94",
+		"jest": "30.2.0",
+		"lint-staged": "16.2.6",
+		"mintlify": "4.2.179",
 		"npm-run-all": "4.1.5",
 		"prettier": "3.6.2",
 		"ratelimit-header-parser": "0.1.0",
 		"supertest": "7.1.4",
-		"ts-jest": "29.4.1",
+		"ts-jest": "29.4.5",
 		"ts-node": "10.9.2",
-		"typescript": "5.9.2"
+		"typescript": "5.9.3"
 	},
 	"prettier": "@express-rate-limit/prettier",
 	"lint-staged": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "myapp",
       "version": "0.0.0",
       "dependencies": {
-        "bcryptjs": "^3.0.2",
+        "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.4.1",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
@@ -17,7 +17,7 @@
         "dotenv": "^17.2.3",
         "express": "^4.21.2",
         "express-mysql-session": "^3.0.3",
-        "express-rate-limit": "^8.1.0",
+        "express-rate-limit": "^8.2.1",
         "express-session": "^1.18.2",
         "express-slow-down": "^3.0.0",
         "express-validator": "^7.3.0",
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/bcryptjs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
-      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
-      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.0.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "cross-env AUTO_OPEN=1 node ./bin/www"
   },
   "dependencies": {
-    "bcryptjs": "^3.0.2",
+    "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.4.1",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
@@ -15,7 +15,7 @@
     "dotenv": "^17.2.3",
     "express": "^4.21.2",
     "express-mysql-session": "^3.0.3",
-    "express-rate-limit": "^8.1.0",
+    "express-rate-limit": "^8.2.1",
     "express-session": "^1.18.2",
     "express-slow-down": "^3.0.0",
     "express-validator": "^7.3.0",

--- a/public/javascripts/login.js
+++ b/public/javascripts/login.js
@@ -20,12 +20,15 @@ var vueinst = new Vue({
       var ptr = this;
       var xhttp = new XMLHttpRequest();
       xhttp.onreadystatechange = function () {
-        if (this.readyState == 4 && this.status == 200) {
+        if (this.readyState !== 4) return;
+        if (this.status === 200) {
           const data = JSON.parse(xhttp.responseText);
           if (data.success === true) {
             console.log("User is logged in");
             window.location.href = "/User_mainpage.html";
           }
+        } else if (this.status === 401) {
+          console.log("No active session; staying on login page.");
         }
       };
       xhttp.open("GET", "/login/checkloginstatus.ajax", true);

--- a/public/javascripts/provider_mainpage.js
+++ b/public/javascripts/provider_mainpage.js
@@ -1,4 +1,5 @@
 const API_PREFIXES_LOGIN = ["/plogin", "/Plogin"];
+const API_PREFIXES_PROVIDER = ["/Provider_main", "/provider_main"];
 
 /** try each candidate URL, return JSON; only 200 is considered successful, 401 throws an explicit error */
 async function tryFetchJSON(method, urlCandidates, payload) {
@@ -69,10 +70,17 @@ var vueinst = new Vue({
       business_name: false,
       description: false,
       password: false,
+      address: false,
     },
     form: {
       business_name: "",
       description: "",
+    },
+    address_form: {
+      address: "",
+      city: "",
+      state: "",
+      postcode: "",
     },
     reset_pass: {
       password: "",
@@ -433,6 +441,13 @@ var vueinst = new Vue({
         this.form.business_name = this.provider_name;
       } else if (field === "description") {
         this.form.description = this.provider_description;
+      } else if (field === "address") {
+        this.address_form = {
+          address: "",
+          city: "",
+          state: "",
+          postcode: "",
+        };
       }
     },
 
@@ -447,6 +462,29 @@ var vueinst = new Vue({
         await this.getProviderInfo();
       } catch (e) {
         alert("Failed to update business name");
+      }
+    },
+
+    async add_address() {
+      const { address, city, state, postcode } = this.address_form;
+      if (!address || !city || !state || !postcode) {
+        alert("All address fields are required.");
+        return;
+      }
+      try {
+        const data = await apiPOST("/add_address", {
+          address,
+          city,
+          state,
+          postcode,
+        });
+        console.log("Address added:", data && data.message);
+        this.editing.address = false;
+        this.address_form = { address: "", city: "", state: "", postcode: "" };
+        await this.getProviderInfo();
+      } catch (e) {
+        console.warn("add_address failed:", e && e.status);
+        alert("Failed to add address. Please try again.");
       }
     },
 

--- a/public/javascripts/signup.js
+++ b/public/javascripts/signup.js
@@ -104,8 +104,11 @@ var vueinst = new Vue({
       xhttp.send(
         JSON.stringify({
           user_name: this.user_name,
+          username: this.user_name,
           user_email: this.user_email,
+          email: this.user_email,
           user_password: this.user_password,
+          password: this.user_password,
           varifyEmailCode: this.varifyEmailCode,
         })
       );
@@ -134,29 +137,51 @@ var vueinst = new Vue({
       var ptr = this;
       var xhttp = new XMLHttpRequest();
       xhttp.onreadystatechange = function () {
-        if (this.readyState == 4 && this.status == 200) {
+        if (this.readyState !== 4) return;
+        if (this.status === 200) {
           const data = JSON.parse(xhttp.responseText);
           alert("registed successful: " + data.message);
           ptr.mode = "whosignup";
           window.location.href = "/provider_login.html";
-        } else if (this.readyState == 4 && this.status == 401) {
-          const data = JSON.parse(xhttp.responseText);
-          alert("registed fail " + data.message);
+          return;
         }
+        let message = "Registration failed.";
+        try {
+          const data = JSON.parse(xhttp.responseText);
+          if (this.status === 400 && Array.isArray(data.errors)) {
+            message =
+              "Validation failed: " +
+              data.errors
+                .map((err) => err.msg || err.param)
+                .filter(Boolean)
+                .join("; ");
+          } else if (data.message) {
+            message = data.message;
+          }
+        } catch (e) {
+          // keep default message
+        }
+        alert(message);
       };
       xhttp.open("POST", "/signup/Pregister.ajax", true);
       xhttp.setRequestHeader("Content-type", "application/json");
       xhttp.send(
         JSON.stringify({
           provider_name: this.provider_name,
+          business_name: this.provider_name,
           provider_email: this.provider_email,
+          email: this.provider_email,
           provider_password: this.provider_password,
-          provider_address: this.provider_address,
+          password: this.provider_password,
           provider_varifyEmailCode: this.provider_varifyEmailCode,
           provider_address: this.provider_address,
+          address: this.provider_address,
           provider_city: this.provider_city,
+          city: this.provider_city,
           provider_state: this.provider_state,
+          state: this.provider_state,
           provider_postcode: this.provider_postcode,
+          postcode: this.provider_postcode,
         })
       );
     },

--- a/public/login.html
+++ b/public/login.html
@@ -47,8 +47,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-pwd"
                 aria-label="Display Password"
                 v-on:click="show()"
               >

--- a/public/provider_login.html
+++ b/public/provider_login.html
@@ -47,8 +47,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-pwd"
                 aria-label="Display Password"
                 v-on:click="show()"
               >

--- a/public/provider_mainpage.html
+++ b/public/provider_mainpage.html
@@ -431,6 +431,116 @@
             </div>
           </div>
 
+          <!-- Manage business address -->
+          <div class="menu-item status-row">
+            <span>Business Address</span>
+            <div style="display: flex; width: 100%; justify-content: flex-end">
+              <template v-if="!editing.address">
+                <div
+                  style="
+                    display: flex;
+                    align-items: center;
+                    gap: 12px;
+                    justify-content: flex-end;
+                    width: 100%;
+                  "
+                >
+                  <div
+                    class="status"
+                    style="
+                      text-align: right;
+                      max-width: 60%;
+                      display: flex;
+                      flex-direction: column;
+                      gap: 4px;
+                      align-items: flex-end;
+                    "
+                  >
+                    <template v-if="provider_address.length === 0">
+                      No address available.
+                    </template>
+                    <ul
+                      v-else
+                      style="
+                        list-style: none;
+                        padding: 0;
+                        margin: 0;
+                        text-align: right;
+                      "
+                    >
+                      <li
+                        v-for="(addr, index) in provider_address"
+                        :key="index"
+                      >
+                        {{ addr.address }}, {{ addr.city }}, {{ addr.state }},
+                        {{ addr.postcode }}
+                      </li>
+                    </ul>
+                  </div>
+                  <button class="btn btn-ghost" @click="toggleEdit('address')">
+                    Add Address
+                  </button>
+                </div>
+              </template>
+              <template v-else>
+                <div
+                  style="
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-end;
+                    gap: 8px;
+                    width: 100%;
+                  "
+                >
+                  <input
+                    class="inline-input"
+                    type="text"
+                    v-model.trim="address_form.address"
+                    placeholder="e.g. 1 Apple Road"
+                    style="max-width: 320px"
+                  />
+                  <div
+                    style="
+                      display: flex;
+                      gap: 8px;
+                      flex-wrap: wrap;
+                      justify-content: flex-end;
+                      width: 100%;
+                    "
+                  >
+                    <input
+                      class="inline-input"
+                      type="text"
+                      v-model.trim="address_form.city"
+                      placeholder="City"
+                      style="max-width: 200px"
+                    />
+                    <input
+                      class="inline-input"
+                      type="text"
+                      v-model.trim="address_form.state"
+                      placeholder="State"
+                      style="max-width: 160px"
+                    />
+                    <input
+                      class="inline-input"
+                      type="text"
+                      v-model.trim="address_form.postcode"
+                      placeholder="Postcode"
+                      style="max-width: 140px"
+                    />
+                  </div>
+                  <div style="display: flex; gap: 8px">
+                    <button class="btn btn-ghost" @click="toggleEdit('address')">
+                      Cancel
+                    </button>
+                    <button class="btn" @click="add_address()">Submit</button>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+
           <!-- Edit password -->
           <div class="menu-item status-row">
             <h4>Password</h4>

--- a/public/signup.html
+++ b/public/signup.html
@@ -99,8 +99,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-pwd"
                 aria-label="Display Password"
                 v-on:click="show()"
               >
@@ -122,8 +121,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-pwd"
                 aria-label="Display Password"
                 v-on:click="cshow()"
               >
@@ -143,8 +141,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-code"
                 v-on:click="c_email_varify()"
               >
                 Get Code
@@ -214,8 +211,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-pwd"
                 aria-label="Display Password"
                 v-on:click="show()"
               >
@@ -237,8 +233,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-pwd"
                 aria-label="Display Password"
                 v-on:click="cshow()"
               >
@@ -247,7 +242,7 @@
             </div>
           </div>
           <div class="field">
-            <label class="label" for="address">Address</label>
+            <label class="label" for="provider_address">Address</label>
             <div class="input-wrap">
               <input
                 id="provider_address"
@@ -259,11 +254,11 @@
             </div>
           </div>
           <div class="field">
-            <label class="label" for="address">City</label>
+            <label class="label" for="provider_city">City</label>
             <div class="input-wrap">
               <input
-                id="provider_address"
-                name="provider_address"
+                id="provider_city"
+                name="provider_city"
                 type="text"
                 v-model="provider_city"
                 placeholder="e.g. Adelaide"
@@ -271,11 +266,11 @@
             </div>
           </div>
           <div class="field">
-            <label class="label" for="address">State</label>
+            <label class="label" for="provider_state">State</label>
             <div class="input-wrap">
               <input
-                id="provider_address"
-                name="provider_address"
+                id="provider_state"
+                name="provider_state"
                 type="text"
                 v-model="provider_state"
                 placeholder="e.g. SA"
@@ -283,11 +278,11 @@
             </div>
           </div>
           <div class="field">
-            <label class="label" for="address">Post Code</label>
+            <label class="label" for="provider_postcode">Post Code</label>
             <div class="input-wrap">
               <input
-                id="provider_address"
-                name="provider_address"
+                id="provider_postcode"
+                name="provider_postcode"
                 type="text"
                 v-model="provider_postcode"
                 placeholder="e.g. 5000"
@@ -306,8 +301,7 @@
               />
               <button
                 type="button"
-                id="togglePwd"
-                class="toggle"
+                class="toggle toggle-code"
                 v-on:click="p_email_varify()"
               >
                 Get Code


### PR DESCRIPTION
Changes delivered across the app:

Auth & signup

Front-end login now treats /login/checkloginstatus.ajax 401s as “not logged in” instead of throwing errors (public/javascripts/login.js).
Customer/provider signup payloads include both legacy and validator field names so back-end validation passes (public/javascripts/signup.js).
Removed duplicate DOM ids in signup forms to avoid console warnings; labels now point to unique inputs (public/signup.html, public/provider_login.html).
Added request-field mapping middleware plus relaxed validator rules so customer/provider signups accept the submitted field names and international text (routes/signup.js, middleware/security.js).
Provider password login upgraded to detect bcrypt hashes as well as legacy SHA-256 (routes/login.js).
Customer dashboard

Search rewritten to normalize case and match provider names, descriptions, and items; 401 responses now keep the login flow tidy (public/javascripts/user_mainpage.js).
History “Report This order” prompts for a reason, posts to the new /User_main/report_order API, and stores reports in the new order_reports table (public/javascripts/user_mainpage.js, routes/User_main.js, database/database.sql).
Provider experience

Introduced API_PREFIXES_PROVIDER and consistent helper functions so provider AJAX calls reach both /Provider_main and /provider_main (public/javascripts/provider_mainpage.js).
Provider Account Setting now includes a Business Address section with right-aligned layout, new-address form, and button alignment matching other actions (public/provider_mainpage.html, public/javascripts/provider_mainpage.js).
Added POST /Provider_main/add_address to persist addresses from the dashboard (routes/Provider_main.js).
Provider signup now reuses pending records, resends verification codes safely, updates provider info, and ensures the submitted business address is stored (creating the provider row if necessary) before seeding the covid status (routes/signup.js).
Infrastructure

Schema import cleans up order_reports before rebuild and defines the table with proper foreign keys (database/database.sql).
With these in place, newly registered providers land in their dashboard with their business address already stored, customers can report orders, and the login/signup flows are more robust.

